### PR TITLE
shamu: disable subsystem ramdump on userdebug builds

### DIFF
--- a/init.shamu.rc
+++ b/init.shamu.rc
@@ -505,8 +505,8 @@ service adspd /system/bin/adspd /dev/ttyHS3
 on property:sys.boot_completed=1
     start qcom-post-boot
 
-on property:ro.debuggable=1
-    start ss_ramdump
+#on property:ro.debuggable=1
+#    start ss_ramdump
 
 on property:ro.data.large_tcp_window_size=true
     # Adjust socket buffer to enlarge TCP receive window for high bandwidth (e.g. DO-RevB)


### PR DESCRIPTION
* left my phone connected to cpu watching monitor while it slept for about 20 mins and it was FULL of ramdumps, this is probably killing battery life so lets kill this and let the dev enable when use is needed